### PR TITLE
update status returned

### DIFF
--- a/health_checker.go
+++ b/health_checker.go
@@ -55,10 +55,10 @@ func (hc *HealthChecker) PerformChecks() HealthCheckResponse {
 
 		if result.Status == StatusFail && check.Importance == Required {
 			overallStatus = StatusFail
-			statusCode = 500
+			statusCode = http.StatusServiceUnavailable
 		} else if result.Status == StatusWarn && overallStatus != StatusFail {
 			overallStatus = StatusWarn
-			statusCode = 429
+			statusCode = http.StatusMultiStatus
 		}
 	}
 

--- a/health_checker_test.go
+++ b/health_checker_test.go
@@ -78,7 +78,7 @@ func TestPerformChecks(t *testing.T) {
 				}}
 				return hc
 			},
-			expected: HealthCheckResponse{Status: StatusFail, StatusCode: 500},
+			expected: HealthCheckResponse{Status: StatusFail, StatusCode: http.StatusServiceUnavailable},
 		},
 		{
 			name: "Optional Check Warns",
@@ -89,7 +89,7 @@ func TestPerformChecks(t *testing.T) {
 				}}
 				return hc
 			},
-			expected: HealthCheckResponse{Status: StatusWarn, StatusCode: 429},
+			expected: HealthCheckResponse{Status: StatusWarn, StatusCode: http.StatusMultiStatus},
 		},
 	}
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Tests


___

### **Description**
- Changed status code for `StatusFail` from 500 to `http.StatusServiceUnavailable` in `health_checker.go`.
- Changed status code for `StatusWarn` from 429 to `http.StatusMultiStatus` in `health_checker.go`.
- Updated test cases in `health_checker_test.go` to reflect the new status codes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>health_checker.go</strong><dd><code>Update status codes in health checker logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

health_checker.go

<li>Changed status code for <code>StatusFail</code> from 500 to <br><code>http.StatusServiceUnavailable</code><br> <li> Changed status code for <code>StatusWarn</code> from 429 to <code>http.StatusMultiStatus</code><br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/healthcheck/pull/7/files#diff-e3a4804c77b3f673ff67925dd5572f6744e9f79288bba2c3afada708cda874aa">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>health_checker_test.go</strong><dd><code>Update test cases for new status codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

health_checker_test.go

<li>Updated expected status codes in test cases to match new status codes <br>in <code>health_checker.go</code><br>


</details>


  </td>
  <td><a href="https://github.com/TykTechnologies/healthcheck/pull/7/files#diff-230ba288a24afe49f0c9290ae343c422beea067d81cb6bc4fb15682a61203194">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

